### PR TITLE
:herb: Add CellValueUnion test

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,7 @@
 # Specify files that shouldn't be modified by Fern
 LICENSE
 README.md
+tests
 
 # Temporary workaround due to audience filtering.
 data_clip_id.go

--- a/tests/cell_value_unions_test.go
+++ b/tests/cell_value_unions_test.go
@@ -1,0 +1,30 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	flatfile "github.com/FlatFilers/flatfile-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCellValueUnion(t *testing.T) {
+	testCases := []struct {
+		value []byte
+	}{
+		{value: []byte("0")},
+		{value: []byte(`""`)},
+		{value: []byte("false")},
+	}
+	for _, testCase := range testCases {
+		t.Run(string(testCase.value), func(t *testing.T) {
+			cellValue := &flatfile.CellValueUnion{}
+			require.NoError(t, json.Unmarshal(testCase.value, cellValue))
+
+			bytes, err := json.Marshal(cellValue)
+			require.NoError(t, err)
+			assert.Equal(t, string(testCase.value), string(bytes))
+		})
+	}
+}


### PR DESCRIPTION
This adds a test to verify that the `CellValueUnion` type can be successfully round-tripped.