### PR TITLE
Fix type alias file upload parameters

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -5,3 +5,5 @@ tests
 
 # Temporary workaround due to audience filtering.
 data_clip_id.go
+
+files/client.go

--- a/files/client.go
+++ b/files/client.go
@@ -5,12 +5,13 @@ package files
 import (
 	bytes "bytes"
 	context "context"
+	io "io"
+	http "net/http"
+
 	flatfilego "github.com/FlatFilers/flatfile-go"
 	core "github.com/FlatFilers/flatfile-go/core"
 	internal "github.com/FlatFilers/flatfile-go/internal"
 	option "github.com/FlatFilers/flatfile-go/option"
-	io "io"
-	http "net/http"
 )
 
 type Client struct {
@@ -104,14 +105,14 @@ func (c *Client) Upload(
 	if err := writer.WriteFile("file", file); err != nil {
 		return nil, err
 	}
-	if err := writer.WriteJSON("spaceId", request.SpaceId); err != nil {
+	if err := writer.WriteField("spaceId", request.SpaceId); err != nil {
 		return nil, err
 	}
-	if err := writer.WriteJSON("environmentId", request.EnvironmentId); err != nil {
+	if err := writer.WriteField("environmentId", request.EnvironmentId); err != nil {
 		return nil, err
 	}
 	if request.Mode != nil {
-		if err := writer.WriteJSON("mode", *request.Mode); err != nil {
+		if err := writer.WriteField("mode", string(*request.Mode)); err != nil {
 			return nil, err
 		}
 	}
@@ -121,7 +122,7 @@ func (c *Client) Upload(
 		}
 	}
 	if request.Origin != nil {
-		if err := writer.WriteJSON("origin", *request.Origin); err != nil {
+		if err := writer.WriteField("origin", string(*request.Origin)); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Reapplying changes from PR #6 with an update to .fernignore to prevent overwriting.